### PR TITLE
Improve runtime for room capacity constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ __pycache__/
 # OS
 .DS_Store
 Thumbs.db
+.venv/

--- a/example/example.py
+++ b/example/example.py
@@ -18,7 +18,7 @@ scheduler.add_constraints([
     AssignAllCourses(),
     NoInstructorOverlap(),
     NoRoomOverlap(),
-    RoomCapacity(),
+    #RoomCapacity(),
     ForceRooms(),
     ForceTimeSlots(),
 ])

--- a/satisfaculty/scheduler.py
+++ b/satisfaculty/scheduler.py
@@ -241,6 +241,7 @@ class InstructorScheduler:
             for room in self.rooms
             for t in self.time_slots
             if self.course_types[course] == self.slot_types[t]
+             and self.enrollments[course] <= self.capacities[room] #Added and instead of using RoomCapacity()
         ])
         self.x = LpVariable.dicts("x", list(self.keys), cat='Binary')
 


### PR DESCRIPTION
I want to be sure this "fix" will not cause issues later. As it essentially REMOVED by commenting out the entire RoomCapacity () function in example.py. Instead, in scheduler.py on line 244 we only create variables for courses and rooms that would meet the capacity requirement. I'm not sure if this is what you want down the road if you want to optimize the classes into certain room sizes with margins. I.e. not put a 12 person class in 80 capacity even though it fits. But this output schedule didn't look different than the one before... and it ran well on regular laptops. Probably require more testing with inputs to be sure as I'm uncomforable completely commenting out Room Capacity()