### PR TITLE
Add MinimizeBackToBack objective

### DIFF
--- a/satisfaculty/__init__.py
+++ b/satisfaculty/__init__.py
@@ -8,6 +8,7 @@ from .objectives import (
     MaximizePreferredRooms,
     MinimizePreferredRooms,
     MaximizeBackToBackCourses,
+    MinimizeBackToBack,
 )
 from .constraints import (
     AssignAllCourses,
@@ -32,6 +33,7 @@ __all__ = [
     "MaximizePreferredRooms",
     "MinimizePreferredRooms",
     "MaximizeBackToBackCourses",
+    "MinimizeBackToBack",
     # Constraints
     "AssignAllCourses",
     "NoInstructorOverlap",


### PR DESCRIPTION
## Summary

- Adds new `MinimizeBackToBack` objective that minimizes back-to-back teaching assignments for all instructors
- Helps ensure instructors have breaks between consecutive classes
- Automatically considers all instructors and their course pairs (unlike `MaximizeBackToBackCourses` which targets specific courses)

## Test plan

- [x] Added unit test `test_minimize_back_to_back` verifying courses are spread to non-adjacent slots
- [x] All existing tests pass (50 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)