### PR TITLE
Add MinimizeScheduleChanges objective for incremental adjustments

### DIFF
--- a/satisfaculty/__init__.py
+++ b/satisfaculty/__init__.py
@@ -10,6 +10,7 @@ from .objectives import (
     MaximizeBackToBackCourses,
     MinimizeBackToBack,
     TargetFill,
+    MinimizeScheduleChanges,
     MinimizeTeachingDaysOver,
 )
 from .constraints import (
@@ -37,6 +38,7 @@ __all__ = [
     "MaximizeBackToBackCourses",
     "MinimizeBackToBack",
     "TargetFill",
+    "MinimizeScheduleChanges",
     "MinimizeTeachingDaysOver",
     # Constraints
     "AssignAllCourses",


### PR DESCRIPTION
Implemented a new objective that minimizes changes from a previous schedule, enabling users to make incremental tweaks while preserving most existing assignments. Supports per-course weights to prioritize keeping certain courses unchanged.

Features:
- Accepts previous schedule as file path or DataFrame
- Reads weights from 'Change Weight' column by default
- Optional weights dict to override column values
- Only penalizes changes; new courses have no penalty

Usage examples:

# From file (reads 'Change Weight' column automatically) MinimizeScheduleChanges('previous_schedule.csv')

# With explicit weights dict
MinimizeScheduleChanges(previous_df, weights={'C1': 10.0, 'C2': 1.0})

# Custom weight column name
MinimizeScheduleChanges('schedule.csv', weight_column='Priority')